### PR TITLE
Match signature of Model.delete()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,9 @@ Example Usage
     ...    class Meta:
     ...        unique_together = ('name', 'live')
     ...
-    ...    def delete(self, *args, **kwargs):
+    ...    def delete(self, using=None):
     ...        self.live = False
-    ...        self.save()
+    ...        self.save(using=using)
     ...
     >>> john = Person.objects.create(name='John Cleese')
     >>> doppelganger = Person(name='John Cleese')


### PR DESCRIPTION
`delete(self)` will work, but at least PyCharm will throw a warning `Signature of method MyClass.delete() does not match signature of base class method in class 'Model'`. Changing to `def delete(self, *args, **kwargs):` fixes this.
