### PR TITLE
Pins django-model-utils due to backwards incompatible change in version 2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_require = (
 
 install_requires = (
     'Django>=1.6,<1.9',
-    'django-model-utils>=2.0,<3.0',
+    'django-model-utils>=2.0,<2.4',
 )
 
 


### PR DESCRIPTION
See https://github.com/carljm/django-model-utils/commit/2824ec2e4875ab6530caa440034959d51d5b9830

/review @adepue 