### PR TITLE
Django-1.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [flake8]
-max-line-length = 119
+max-line-length = 135

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-livefield',
-    version='2.6.0',
+    version='2.7.0',
     description='Convenient soft-deletion support for Django models',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/livefield/fields.py
+++ b/src/livefield/fields.py
@@ -1,3 +1,4 @@
+import django
 from django.db import models
 
 
@@ -34,6 +35,19 @@ class LiveField(models.NullBooleanField):
             msg = u"%(model)s doesn't support filters or excludes with %(field)s=False. Try using %(field)s=None."
             raise TypeError(msg % {'model': self.model.__name__, 'field': self.name})  # pylint: disable=no-member
         return super(LiveField, self).get_prep_lookup(lookup_type, value)
+
+
+class LiveFieldExact(models.lookups.Exact):
+    def get_db_prep_lookup(self, value, connection):
+        if not value:
+            msg = u"LiveField doesn't support filters or excludes with a livefield=False. Try using livefield=None."
+            raise TypeError(msg)  # pylint: disable=no-member
+        return super(LiveFieldExact, self).get_db_prep_lookup(value, connection)  # pylint: disable=too-many-function-args
+
+
+# Only do this for Django >= 1.10
+if django.get_version().startswith("1.1"):
+    LiveField.register_lookup(LiveFieldExact)
 
 
 try:


### PR DESCRIPTION
Due to the fact that Django 1.10 removes get_prep_lookup on models.Field, we don't explicitly block live=False lookups through filter/exclude https://github.com/hearsaycorp/django-livefield/blob/master/src/livefield/fields.py#L35

We need to update that as noted in release notes: https://docs.djangoproject.com/en/1.10/releases/1.10/#field-get-prep-lookup-and-field-get-db-prep-lookup-methods-are-removed 