### PR TITLE
Update package meta to support Django 2.2 and Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,3 +92,6 @@ before_script:
 script:
   - "python setup.py test"
   - "./lint.sh"
+services:
+    - mysql
+    - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.5
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-      - python: 3.5
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        #      - python: 3.5
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.5
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.6
@@ -51,36 +51,36 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.6
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-      - python: 3.6
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        #      - python: 3.6
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.6
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=sqlite
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=sqlite
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
-      - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        #      - python: 3.7
+        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.5
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.5
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.5
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.6
         env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
       - python: 3.6
@@ -45,7 +51,12 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,30 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
       - python: 3.5
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.6
@@ -55,7 +55,7 @@ matrix:
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
       - python: 3.6
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.7
@@ -79,7 +79,7 @@ matrix:
       - python: 3.7
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
       - python: 3.7
-        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.7
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.5
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.5
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.5
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.5
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
       - python: 3.5
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.6
@@ -52,36 +52,36 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.6
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.6
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
-        #      - python: 3.7
-        #        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.2 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=sqlite
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgre
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='python django soft-delete',
     url='https://github.com/hearsaycorp/django-livefield',

--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,9 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require = (
 
 
 install_requires = (
-    'Django>=1.11,<2.2',
+    'Django>=1.11,<2.3',
 )
 
 

--- a/src/livefield/managers.py
+++ b/src/livefield/managers.py
@@ -9,10 +9,10 @@ class LiveManagerBase(models.Manager):
 
     def __init__(self, include_soft_deleted=False, *args, **kwargs):
         self.include_soft_deleted = include_soft_deleted
-        super(LiveManagerBase, self).__init__(*args, **kwargs)  # pylint: disable=super-on-old-class
+        super(LiveManagerBase, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
-        qs = super(LiveManagerBase, self).get_queryset()  # pylint: disable=super-on-old-class
+        qs = super(LiveManagerBase, self).get_queryset()
         if not self.include_soft_deleted:
             return qs.live()
         return qs

--- a/src/livefield/models.py
+++ b/src/livefield/models.py
@@ -23,7 +23,7 @@ class LiveModel(models.Model):
     def delete(self):
         self.soft_delete()
 
-    def hard_delete(self):  # pylint: disable=super-on-old-class
+    def hard_delete(self):
         super(LiveModel, self).delete()
 
     def soft_delete(self):


### PR DESCRIPTION
Regarding the issue #50 (_release with Django 2.2 support_) I've added 2.2 to requirements and to the test matrix.

I've also added Python 3.7 to these files because it seems like package works pretty good with python 3.7.

Let me know if it's neccessary to split these two changes to separate PRs.