### PR TITLE
Adjust requirements to allow use with Django3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.7
         env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
       - python: 3.7
@@ -82,6 +86,19 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.7
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 | `John Lynn <http://github.com/jlynn>`_
 | `Dylan Verheul <http://github.com/dyve>`_
 | `Grant McConnaughey <http://github.com/grantmcconnaughey>`_
+| `Luke Burden <http://github.com/lukeburden>`_

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require = (
 
 
 install_requires = (
-    'Django>=1.11,<2.3',
+    'Django>=1.11,<4',
 )
 
 


### PR DESCRIPTION
Changes to allow support for Django3 and Python3.8, plus Travis bits.

It's probably a good time to drop support for python2.7 too, @hearsaydev, and do a major version bump to indicate the backward compat breakage.

Thanks!