### PR TITLE
Django 3.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.6
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.6
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
       - python: 3.7
         env: DJANGO_VERSION_CEILING=1.12 DJANGO_DB_ENGINE=sqlite
       - python: 3.7
@@ -82,6 +86,19 @@ matrix:
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
       - python: 3.7
         env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.7
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=2.3 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+      - python: 3.8
+        env: DJANGO_VERSION_CEILING=3.1 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+
 install:
   - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - "pip install flake8 pylint pytest pytest-django"

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Contributors
 | `Dylan Verheul <http://github.com/dyve>`_
 | `Grant McConnaughey <http://github.com/grantmcconnaughey>`_
 | `Luke Burden <http://github.com/lukeburden>`_
+| `James Addison <http://github.com/jaddison>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 | `John Lynn <http://github.com/jlynn>`_
 | `Dylan Verheul <http://github.com/dyve>`_
 | `Grant McConnaughey <http://github.com/grantmcconnaughey>`_
+| `Luke Burden <http://github.com/lukeburden>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.3.0
+--------------------
+    - Django 3.x support
+    - switch to BooleanField as base (Django 4.x deprecation)
+
 3.2.1
 --------------------
     - Fix rST formatting in this file to pass PyPI rendering check

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-livefield',
-    version='3.2.1',
+    version='3.3.0',
     description='Convenient soft-deletion support for Django models',
     long_description=(
         open('README.rst').read() + '\n\n' +
@@ -79,6 +79,8 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require = (
 
 
 install_requires = (
-    'Django>=1.11,<2.3',
+    'Django>=1.11,<4',
 )
 
 

--- a/src/livefield/fields.py
+++ b/src/livefield/fields.py
@@ -2,7 +2,7 @@ import django
 from django.db import models
 
 
-class LiveField(models.NullBooleanField):
+class LiveField(models.BooleanField):
     """Support uniqueness constraints and soft-deletion.
 
     Similar to a BooleanField, but stores False as NULL. This lets us use
@@ -14,7 +14,7 @@ class LiveField(models.NullBooleanField):
     description = u'Soft-deletion status'
 
     def __init__(self, *args, **kwargs):
-        super(LiveField, self).__init__(default=True, null=True)
+        super(LiveField, self).__init__(default=True, null=True, blank=True)
 
     def get_prep_value(self, value):
         # Convert in-Python value to value we'll store in DB

--- a/src/livefield/fields.py
+++ b/src/livefield/fields.py
@@ -1,8 +1,13 @@
 import django
 from django.db import models
 
+if django.VERSION < (2, 1):
+    BooleanField = models.NullBooleanField
+else:
+    BooleanField = models.BooleanField
 
-class LiveField(models.BooleanField):
+
+class LiveField(BooleanField):
     """Support uniqueness constraints and soft-deletion.
 
     Similar to a BooleanField, but stores False as NULL. This lets us use


### PR DESCRIPTION
This directly builds off of https://github.com/hearsaycorp/django-livefield/pull/55 by @lukeburden. If acceptable, this can replace that PR.

Also added dynamic model adjustment for Django 4.x deprecation (`NullBooleanField` to be removed).